### PR TITLE
feat: DB-driven branding, public tiers API, and external conversion webhook

### DIFF
--- a/prisma/migrations/20260419000000_add_conversion_idempotency_source_tag/migration.sql
+++ b/prisma/migrations/20260419000000_add_conversion_idempotency_source_tag/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: add idempotencyKey + sourceTag to conversions
+ALTER TABLE "conversions" ADD COLUMN "idempotency_key" TEXT;
+ALTER TABLE "conversions" ADD COLUMN "source_tag" TEXT NOT NULL DEFAULT 'default';
+CREATE UNIQUE INDEX "conversions_idempotency_key_key" ON "conversions"("idempotency_key");
+
+-- AlterTable: add sourceTag to program_settings
+ALTER TABLE "program_settings" ADD COLUMN "source_tag" TEXT NOT NULL DEFAULT 'default';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,22 +8,37 @@ datasource db {
 }
 
 model User {
-  id             String       @id @default(cuid())
-  email          String       @unique
+  id             String                @id @default(cuid())
+  email          String                @unique
   name           String
   password       String
-  role           Role         @default(AFFILIATE)
-  status         UserStatus   @default(PENDING)
-  lastLogin      DateTime?    @map("last_login")
-  createdAt      DateTime     @default(now()) @map("created_at")
-  updatedAt      DateTime     @updatedAt @map("updated_at")
-  profilePicture String?      @map("profile_picture")
+  role           Role                  @default(AFFILIATE)
+  status         UserStatus            @default(PENDING)
+  lastLogin      DateTime?             @map("last_login")
+  createdAt      DateTime              @default(now()) @map("created_at")
+  updatedAt      DateTime              @updatedAt @map("updated_at")
+  profilePicture String?               @map("profile_picture")
   affiliate      Affiliate?
   auditLogs      AuditLog[]
   commissions    Commission[]
   payouts        Payout[]
+  resetTokens    PasswordResetToken[]
 
   @@map("users")
+}
+
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  userId    String   @map("user_id")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt DateTime @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([token])
+  @@index([userId])
+  @@map("password_reset_tokens")
 }
 
 model Affiliate {
@@ -90,10 +105,12 @@ model Conversion {
   amountCents   Int              @map("amount_cents")
   currency      String           @default("USD")
   status        ConversionStatus @default(PENDING)
-  eventMetadata Json             @default("{}") @map("event_metadata")
-  createdAt     DateTime         @default(now()) @map("created_at")
-  updatedAt     DateTime         @updatedAt @map("updated_at")
-  commissions   Commission[]
+  eventMetadata   Json             @default("{}") @map("event_metadata")
+  idempotencyKey  String?          @unique @map("idempotency_key")
+  sourceTag       String?          @default("default") @map("source_tag")
+  createdAt       DateTime         @default(now()) @map("created_at")
+  updatedAt       DateTime         @updatedAt @map("updated_at")
+  commissions     Commission[]
   affiliate     Affiliate        @relation(fields: [affiliateId], references: [id], onDelete: Cascade)
   referral      Referral?        @relation(fields: [referralId], references: [id])
 
@@ -185,6 +202,9 @@ model OTP {
   @@map("otps")
 }
 
+// defaultPartnerCode: referral code used when no affiliate attribution exists.
+// Set to the super-admin's code so all organic signups have a tracking anchor.
+// The admin role is exempt from earning commission on these (see tier-escalation).
 model ProgramSettings {
   id                        String   @id @default(cuid())
   programId                 String   @unique @map("program_id")
@@ -194,6 +214,8 @@ model ProgramSettings {
   currency                  String   @default("INR")
   blockedCountries          Json     @default("[]") @map("blocked_countries")
   portalSubdomain           String   @map("portal_subdomain")
+  defaultPartnerCode        String?  @map("default_partner_code") // fallback referral code for organic signups
+  sourceTag                 String   @default("default") @map("source_tag") // identifies this program instance (e.g. "hotel-main", "saas-app")
   termsOfService            String?  @map("terms_of_service")
   minimumPayoutThreshold    Int      @default(0) @map("minimum_payout_threshold")
   payoutTerm                String   @default("NET-15") @map("payout_term")
@@ -226,15 +248,16 @@ model ProgramSettings {
 }
 
 model PartnerGroup {
-  id             String      @id @default(cuid())
-  name           String
-  description    String?
-  commissionRate Float       @map("commission_rate")
-  signupUrl      String?     @map("signup_url")
-  isDefault      Boolean     @default(false) @map("is_default")
-  createdAt      DateTime    @default(now()) @map("created_at")
-  updatedAt      DateTime    @updatedAt @map("updated_at")
-  affiliates     Affiliate[]
+  id               String      @id @default(cuid())
+  name             String
+  description      String?
+  commissionRate   Float       @map("commission_rate")
+  tierThreshold    Int?        @map("tier_threshold") // min active merchants to auto-enter this tier
+  signupUrl        String?     @map("signup_url")
+  isDefault        Boolean     @default(false) @map("is_default")
+  createdAt        DateTime    @default(now()) @map("created_at")
+  updatedAt        DateTime    @updatedAt @map("updated_at")
+  affiliates       Affiliate[]
 
   @@map("partner_groups")
 }
@@ -435,6 +458,7 @@ enum EmailTemplateType {
   COMMISSION_APPROVED
   PAYOUT_GENERATED
   REFERRAL_CONVERTED
+  PASSWORD_RESET
 }
 
 enum EmailStatus {

--- a/prisma/seeds/example-hotel.ts
+++ b/prisma/seeds/example-hotel.ts
@@ -1,0 +1,196 @@
+/**
+ * prisma/seeds/example-hotel.ts
+ *
+ * Generic seed for a hotel / subscription-based Refferq deployment.
+ *
+ * All values are driven by environment variables so this file contains
+ * zero brand-specific strings and is safe to commit to the upstream repo.
+ *
+ * Required env vars (set in .env or deployment environment):
+ *   PROGRAM_ID            — unique slug for this program (e.g. "main")
+ *   PROGRAM_NAME          — display name shown in the partner portal
+ *   PRODUCT_NAME          — the product / service being sold
+ *   COMPANY_NAME          — legal / brand company name
+ *   WEBSITE_URL           — public website of the business
+ *   PORTAL_SUBDOMAIN      — subdomain for the partner portal
+ *   CURRENCY              — ISO 4217 code, defaults to "INR"
+ *   PAYOUT_METHODS        — JSON array string, defaults to '["UPI_BANK"]'
+ *                           Example values: '["UPI_BANK"]', '["PAYPAL","BANK_TRANSFER"]'
+ *                           For hotel/subscription deployments with manual bank/UPI payouts:
+ *                           set PAYOUT_METHODS='["UPI_BANK"]'
+ *   SOURCE_TAG            — identifies this deployment instance (e.g. "hotel-main")
+ *   DEFAULT_PARTNER_CODE  — fallback referral code for organic signups (optional)
+ *
+ * Tier configuration (commission rates stored as decimals, e.g. 0.20 = 20%):
+ *   TIER_1_NAME           — defaults to "Standard"
+ *   TIER_1_RATE           — decimal, defaults to "0.20" (20%)
+ *   TIER_1_THRESHOLD      — min active referrals to enter tier; defaults to "0" (entry tier)
+ *   TIER_2_NAME           — defaults to "Silver"
+ *   TIER_2_RATE           — decimal, defaults to "0.25" (25%)
+ *   TIER_2_THRESHOLD      — defaults to "10"
+ *   TIER_3_NAME           — defaults to "Gold"
+ *   TIER_3_RATE           — decimal, defaults to "0.30" (30%)
+ *   TIER_3_THRESHOLD      — defaults to "25"
+ *
+ * Safe to run multiple times — all writes are upserts keyed on stable identifiers.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function requireEnv(name: string, fallback?: string): string {
+  const value = process.env[name] ?? fallback;
+  if (value === undefined || value === '') {
+    throw new Error(
+      `[example-hotel seed] Missing required env var: ${name}. ` +
+        `Set it in .env or pass it to the seed command.`,
+    );
+  }
+  return value;
+}
+
+function envFloat(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseFloat(raw);
+  if (isNaN(n)) throw new Error(`[example-hotel seed] ${name} must be a number, got: ${raw}`);
+  return n;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  if (isNaN(n)) throw new Error(`[example-hotel seed] ${name} must be an integer, got: ${raw}`);
+  return n;
+}
+
+function envJson<T>(name: string, fallback: T): T {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new Error(`[example-hotel seed] ${name} must be valid JSON, got: ${raw}`);
+  }
+}
+
+// ─── Seed ────────────────────────────────────────────────────────────────────
+
+export async function seedExampleHotel() {
+  console.log('[example-hotel] Seeding ProgramSettings...');
+
+  // ── ProgramSettings ──────────────────────────────────────────────────────
+  // payoutMethods is DB-driven; deployments choose their preferred method via
+  // the PAYOUT_METHODS env var (JSON array). Hotel/subscription deployments
+  // typically use '["UPI_BANK"]' for manual bank/UPI transfer payouts.
+  // No code change is needed to switch methods — update DB via this seed or
+  // the admin settings UI.
+
+  const programId = requireEnv('PROGRAM_ID', 'main');
+
+  await prisma.programSettings.upsert({
+    where: { programId },
+    update: {
+      programName: requireEnv('PROGRAM_NAME', 'Partner Program'),
+      productName: requireEnv('PRODUCT_NAME', 'Subscription'),
+      companyName: process.env.COMPANY_NAME ?? null,
+      websiteUrl: requireEnv('WEBSITE_URL', 'https://example.com'),
+      portalSubdomain: requireEnv('PORTAL_SUBDOMAIN', 'partners'),
+      currency: process.env.CURRENCY ?? 'INR',
+      sourceTag: process.env.SOURCE_TAG ?? 'default',
+      defaultPartnerCode: process.env.DEFAULT_PARTNER_CODE ?? null,
+      payoutMethods: envJson<string[]>('PAYOUT_METHODS', ['UPI_BANK']),
+    },
+    create: {
+      programId,
+      programName: requireEnv('PROGRAM_NAME', 'Partner Program'),
+      productName: requireEnv('PRODUCT_NAME', 'Subscription'),
+      companyName: process.env.COMPANY_NAME ?? null,
+      websiteUrl: requireEnv('WEBSITE_URL', 'https://example.com'),
+      portalSubdomain: requireEnv('PORTAL_SUBDOMAIN', 'partners'),
+      currency: process.env.CURRENCY ?? 'INR',
+      sourceTag: process.env.SOURCE_TAG ?? 'default',
+      defaultPartnerCode: process.env.DEFAULT_PARTNER_CODE ?? null,
+      payoutMethods: envJson<string[]>('PAYOUT_METHODS', ['UPI_BANK']),
+    },
+  });
+
+  console.log('[example-hotel] Seeding PartnerGroups (3 tiers)...');
+
+  // ── PartnerGroups (tiers) ────────────────────────────────────────────────
+  // Each tier is upserted by name. If names change, old rows are left in place.
+  // Rates stored as decimals: 0.20 = 20%.
+
+  const tiers = [
+    {
+      name: process.env.TIER_1_NAME ?? 'Standard',
+      description: process.env.TIER_1_DESC ?? 'Entry-level partner tier',
+      commissionRate: envFloat('TIER_1_RATE', 0.20),
+      tierThreshold: envInt('TIER_1_THRESHOLD', 0),   // 0 = entry tier, no minimum
+      isDefault: true,
+    },
+    {
+      name: process.env.TIER_2_NAME ?? 'Silver',
+      description: process.env.TIER_2_DESC ?? 'Mid-level partner tier',
+      commissionRate: envFloat('TIER_2_RATE', 0.25),
+      tierThreshold: envInt('TIER_2_THRESHOLD', 10),
+      isDefault: false,
+    },
+    {
+      name: process.env.TIER_3_NAME ?? 'Gold',
+      description: process.env.TIER_3_DESC ?? 'Top-level partner tier',
+      commissionRate: envFloat('TIER_3_RATE', 0.30),
+      tierThreshold: envInt('TIER_3_THRESHOLD', 25),
+      isDefault: false,
+    },
+  ];
+
+  for (const tier of tiers) {
+    const existing = await prisma.partnerGroup.findFirst({
+      where: { name: tier.name },
+    });
+
+    if (existing) {
+      await prisma.partnerGroup.update({
+        where: { id: existing.id },
+        data: {
+          description: tier.description,
+          commissionRate: tier.commissionRate,
+          tierThreshold: tier.tierThreshold === 0 ? null : tier.tierThreshold,
+          isDefault: tier.isDefault,
+        },
+      });
+      console.log(`[example-hotel]   Updated tier: ${tier.name} (${tier.commissionRate * 100}%)`);
+    } else {
+      await prisma.partnerGroup.create({
+        data: {
+          name: tier.name,
+          description: tier.description,
+          commissionRate: tier.commissionRate,
+          tierThreshold: tier.tierThreshold === 0 ? null : tier.tierThreshold,
+          isDefault: tier.isDefault,
+        },
+      });
+      console.log(`[example-hotel]   Created tier: ${tier.name} (${tier.commissionRate * 100}%)`);
+    }
+  }
+
+  console.log('[example-hotel] Done.');
+}
+
+// ─── Standalone entrypoint ───────────────────────────────────────────────────
+// Run directly:  npx ts-node prisma/seeds/example-hotel.ts
+// Or via main seed.ts (see prisma/seed.ts).
+
+if (require.main === module) {
+  seedExampleHotel()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/src/app/api/external/conversion/route.ts
+++ b/src/app/api/external/conversion/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Verify HMAC-SHA256 from x-webhook-signature header (accepts raw hex or "sha256=<hex>"). */
+function verifySignature(body: string, signature: string, secret: string): boolean {
+  try {
+    const expected = createHmac('sha256', secret).update(body).digest('hex');
+    const sigHex = signature.replace(/^sha256=/, '');
+    const expectedBuf = Buffer.from(expected, 'hex');
+    const actualBuf = Buffer.from(sigHex, 'hex');
+    if (expectedBuf.length !== actualBuf.length) return false;
+    return timingSafeEqual(expectedBuf, actualBuf);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/external/conversion
+// ---------------------------------------------------------------------------
+// Called by an integrated product after a successful purchase / subscription.
+// Auth: HMAC-SHA256 over raw request body using WEBHOOK_SECRET env var.
+//
+// Request body (JSON):
+//   referral_code    string  — affiliate referral code
+//   customer_email   string  — purchasing customer's email
+//   order_value      number  — order amount in major currency units (e.g. 99.00)
+//   idempotency_key  string  — caller-supplied unique key; re-submits are safe
+//   source_tag?      string  — optional label (e.g. "checkout", "upgrade")
+//   currency?        string  — ISO 4217, defaults to "INR"
+//   event_type?      string  — SIGNUP | PURCHASE | TRIAL | LEAD; defaults to "PURCHASE"
+//
+// Response 201: { status: "created",   conversion_id: string }
+// Response 200: { status: "already_processed", conversion_id: string }
+// ---------------------------------------------------------------------------
+
+export async function POST(req: NextRequest) {
+  // ── 1. Verify HMAC signature ──────────────────────────────────────────────
+  const signature = req.headers.get('x-webhook-signature') ?? '';
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    console.error('POST /api/external/conversion: WEBHOOK_SECRET not configured');
+    return NextResponse.json(
+      { error: 'Webhook secret not configured' },
+      { status: 500 },
+    );
+  }
+
+  const rawBody = await req.text();
+
+  if (!verifySignature(rawBody, signature, webhookSecret)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  // ── 2. Parse & validate body ──────────────────────────────────────────────
+  let body: {
+    referral_code: string;
+    customer_email: string;
+    order_value: number;
+    idempotency_key: string;
+    source_tag?: string;
+    currency?: string;
+    event_type?: string;
+  };
+
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const {
+    referral_code,
+    customer_email,
+    order_value,
+    idempotency_key,
+    source_tag,
+    currency,
+    event_type,
+  } = body;
+
+  if (!referral_code || !customer_email || order_value == null || !idempotency_key) {
+    return NextResponse.json(
+      {
+        error:
+          'Missing required fields: referral_code, customer_email, order_value, idempotency_key',
+      },
+      { status: 400 },
+    );
+  }
+
+  const allowedEventTypes = ['SIGNUP', 'PURCHASE', 'TRIAL', 'LEAD'] as const;
+  type ValidEventType = (typeof allowedEventTypes)[number];
+
+  const resolvedEventType: ValidEventType =
+    allowedEventTypes.includes((event_type ?? '').toUpperCase() as ValidEventType)
+      ? ((event_type!.toUpperCase()) as ValidEventType)
+      : 'PURCHASE';
+
+  // ── 3. Idempotency — check for existing conversion with same key ──────────
+  // The Conversion model stores idempotency_key inside eventMetadata JSON.
+  const existing = await prisma.conversion.findFirst({
+    where: {
+      eventMetadata: {
+        path: ['idempotency_key'],
+        equals: idempotency_key,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    return NextResponse.json(
+      { status: 'already_processed', conversion_id: existing.id },
+      { status: 200 },
+    );
+  }
+
+  // ── 4. Look up affiliate by referral code ─────────────────────────────────
+  const affiliate = await prisma.affiliate.findUnique({
+    where: { referralCode: referral_code },
+    include: { user: { select: { email: true, status: true } } },
+  });
+
+  if (!affiliate) {
+    return NextResponse.json({ error: 'Invalid referral code' }, { status: 404 });
+  }
+
+  // ── 5. Self-referral guard ────────────────────────────────────────────────
+  if (affiliate.user?.email?.toLowerCase() === customer_email.toLowerCase()) {
+    return NextResponse.json({ error: 'Self-referral not allowed' }, { status: 422 });
+  }
+
+  // ── 6. Convert order_value (major units) → cents ──────────────────────────
+  const amountCents = Math.round(order_value * 100);
+
+  // ── 7. Create conversion record ───────────────────────────────────────────
+  // customer_email, idempotency_key, and source_tag live in eventMetadata
+  // because the Conversion model has no dedicated columns for them.
+  const conversion = await prisma.conversion.create({
+    data: {
+      affiliateId: affiliate.id,
+      eventType: resolvedEventType,
+      amountCents,
+      currency: (currency ?? 'INR').toUpperCase(),
+      status: 'PENDING',
+      eventMetadata: {
+        customer_email,
+        idempotency_key,
+        source_tag: source_tag ?? 'default',
+      },
+    },
+  });
+
+  return NextResponse.json(
+    { status: 'created', conversion_id: conversion.id },
+    { status: 201 },
+  );
+}

--- a/src/app/api/public/tiers/route.ts
+++ b/src/app/api/public/tiers/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/public/tiers
+ *
+ * Returns partner tier groups ordered by commission rate ascending.
+ * Public endpoint — no auth required.
+ */
+export async function GET() {
+  try {
+    const tiers = await prisma.partnerGroup.findMany({
+      orderBy: { commissionRate: 'asc' },
+      select: {
+        id: true,
+        name: true,
+        commissionRate: true,
+        tierThreshold: true,
+      },
+    });
+    return NextResponse.json(tiers);
+  } catch (error) {
+    console.error('Failed to fetch tiers:', error);
+    return NextResponse.json([], { status: 200 });
+  }
+}

--- a/src/app/api/public/tracking-snippet/route.ts
+++ b/src/app/api/public/tracking-snippet/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/public/tracking-snippet
+ *
+ * Returns the JavaScript tracking snippet that merchant sites embed.
+ * The snippet:
+ *   1. Reads the affiliate_attribution cookie (set by /r/[code] redirect)
+ *   2. Also reads ?ref= query param as fallback
+ *   3. Exposes window.PartnerPortal.trackConversion(email, amount, currency) for
+ *      merchant sites to call after a successful signup or subscription payment
+ *
+ * No auth required — public endpoint, script contains no secrets.
+ */
+export async function GET() {
+  // Resolve default referral code: ProgramSettings.defaultPartnerCode > env var > empty string
+  let defaultRef = process.env.DEFAULT_PARTNER_CODE || '';
+  try {
+    const settings = await prisma.programSettings.findFirst({
+      select: { defaultPartnerCode: true },
+    });
+    if (settings?.defaultPartnerCode) {
+      defaultRef = settings.defaultPartnerCode;
+    }
+  } catch (_) {
+    // Non-fatal — fall back to env var / empty string
+  }
+
+  // PORTAL_URL and TRACKING_API_KEY must be set in the deployment environment.
+  // PORTAL_URL: public base URL of this Refferq instance (e.g. https://app.example.com)
+  // TRACKING_API_KEY: public (non-secret) API key embedded in the client-side snippet
+  const portalUrl = process.env.PORTAL_URL || process.env.NEXT_PUBLIC_APP_URL || '';
+  const trackingApiKey = process.env.TRACKING_API_KEY || '';
+
+  const snippet = `
+(function(w) {
+  'use strict';
+  var PORTAL = '${portalUrl}';
+  var PUBLIC_KEY = '${trackingApiKey}';
+  var DEFAULT_REF = '${defaultRef}';
+
+  function getCookie(name) {
+    try {
+      var m = document.cookie.match('(^|;)\\\\s*' + name + '\\\\s*=\\\\s*([^;]+)');
+      return m ? decodeURIComponent(m.pop()) : null;
+    } catch(e) { return null; }
+  }
+
+  function getUrlParam(name) {
+    try {
+      return new URLSearchParams(w.location.search).get(name);
+    } catch(e) { return null; }
+  }
+
+  function getAttribution() {
+    // Priority: cookie > URL param > default
+    var cookie = getCookie('affiliate_attribution');
+    if (cookie) {
+      try { return JSON.parse(cookie); } catch(e) {}
+    }
+    var ref = getUrlParam('ref');
+    if (ref) return { referral_code: ref };
+    return { referral_code: DEFAULT_REF };
+  }
+
+  function trackConversion(customerEmail, amount, currency, orderId, metadata) {
+    var attr = getAttribution();
+    var payload = {
+      referralCode: attr.referral_code || DEFAULT_REF,
+      customerEmail: customerEmail || '',
+      amount: amount || 0,
+      currency: currency || 'INR',
+      orderId: orderId || null,
+      url: w.location.href,
+      timestamp: new Date().toISOString(),
+      metadata: Object.assign({ attribution_key: attr.attribution_key }, metadata || {})
+    };
+    fetch(PORTAL + '/api/track/conversion', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': PUBLIC_KEY
+      },
+      body: JSON.stringify(payload),
+      keepalive: true
+    }).then(function(r) {
+      if (!r.ok) r.json().then(function(d) { console.warn('[PartnerPortal] Conversion track failed:', d); });
+    }).catch(function(e) { console.warn('[PartnerPortal] Conversion track error:', e); });
+  }
+
+  function setAttributionCookie(code) {
+    // Only set if not already attributed — first-click wins
+    if (getCookie('affiliate_attribution')) return;
+    var expires = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toUTCString();
+    document.cookie = 'affiliate_attribution=' + encodeURIComponent(JSON.stringify({
+      referral_code: code,
+      attribution_key: code + '_' + Date.now()
+    })) + '; expires=' + expires + '; path=/; SameSite=Lax';
+  }
+
+  function trackClick(referralCode) {
+    var code = referralCode || getUrlParam('ref');
+    if (!code) return;
+    setAttributionCookie(code);
+    fetch(PORTAL + '/api/track/referral', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': PUBLIC_KEY },
+      body: JSON.stringify({
+        referralCode: code,
+        url: w.location.href,
+        referrer: document.referrer,
+        userAgent: navigator.userAgent,
+        timestamp: new Date().toISOString()
+      }),
+      keepalive: true
+    }).catch(function(){});
+  }
+
+  // Auto-track click on page load if ?ref= is in URL
+  if (getUrlParam('ref')) { trackClick(getUrlParam('ref')); }
+
+  w.PartnerPortal = { trackConversion: trackConversion, trackClick: trackClick, getAttribution: getAttribution };
+})(window);
+`.trim();
+
+  return new NextResponse(snippet, {
+    headers: {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,311 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Target, TrendingUp, Users, DollarSign, Award, Zap, ArrowRight, CheckCircle } from 'lucide-react';
+
+// Tier colour palette cycles by index so layout stays visually distinct
+const TIER_STYLES = [
+  { color: 'from-amber-700 to-amber-500', border: 'border-amber-500/30', badge: 'bg-amber-900/30 text-amber-400' },
+  { color: 'from-slate-400 to-slate-300', border: 'border-slate-400/40',  badge: 'bg-slate-700/40 text-slate-300',  highlight: true },
+  { color: 'from-yellow-500 to-yellow-300', border: 'border-yellow-500/40', badge: 'bg-yellow-900/30 text-yellow-400' },
+  { color: 'from-emerald-500 to-emerald-300', border: 'border-emerald-500/40', badge: 'bg-emerald-900/30 text-emerald-400' },
+];
+
+const HOW_IT_WORKS = [
+  { icon: Users,       step: '01', title: 'Register as a Partner', body: 'Create your partner account and get your unique referral link in minutes.' },
+  { icon: Zap,         step: '02', title: 'Share Your Link',        body: 'Share your referral link with merchants — on your blog, social, email, or direct.' },
+  { icon: TrendingUp,  step: '03', title: 'Merchants Sign Up',      body: 'When a merchant registers via your link and activates their account, you earn.' },
+  { icon: DollarSign,  step: '04', title: 'Earn Every Month',       body: 'Collect recurring commission for as long as the merchant stays active. No cap.' },
+];
+
+const BENEFITS = [
+  'Recurring lifetime commission — earn monthly, not once',
+  'Auto-tier upgrades — automatically unlock higher rates as you grow',
+  'Real-time earnings dashboard with payout tracking',
+  '90-day attribution window — get credit even if merchants take time to decide',
+  'Monthly payouts on the 15th — no minimum holdups',
+  'Dedicated partner support and resources',
+];
+
+interface Tier {
+  id: string;
+  name: string;
+  commissionRate: number;
+  tierThreshold: number | null;
+}
+
+interface BrandingSettings {
+  companyName?: string;
+  programName?: string;
+  companyLogo?: string | null;
+  brandBackgroundColor?: string;
+  brandButtonColor?: string;
+  brandTextColor?: string;
+}
+
+async function fetchBranding(): Promise<BrandingSettings> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/affiliate/branding`, { cache: 'no-store' });
+    if (!res.ok) return {};
+    const data = await res.json();
+    return data.settings ?? {};
+  } catch {
+    return {};
+  }
+}
+
+async function fetchTiers(): Promise<Tier[]> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/public/tiers`, { cache: 'no-store' });
+    if (!res.ok) return [];
+    return res.json();
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata() {
+  const branding = await fetchBranding();
+  const programName = branding.programName || process.env.PROGRAM_NAME || 'Partner Program';
+  const companyName = branding.companyName || process.env.COMPANY_NAME || 'Partner Portal';
+  return {
+    title: `${programName} — ${companyName}`,
+    description: `Join the ${programName} and earn recurring commissions for every merchant you refer.`,
+  };
+}
+
+export default async function JoinPage() {
+  const [branding, tiers] = await Promise.all([fetchBranding(), fetchTiers()]);
+
+  const programName = branding.programName || process.env.PROGRAM_NAME || 'Partner Program';
+  const companyName = branding.companyName || process.env.COMPANY_NAME || 'Partner Portal';
+
+  // Derive a human-readable max rate string for the hero badge
+  const maxRate = tiers.length > 0
+    ? `${Math.round(Math.max(...tiers.map((t) => t.commissionRate)) * 100)}%`
+    : null;
+
+  const heroRateRange = tiers.length >= 2
+    ? `${Math.round(Math.min(...tiers.map((t) => t.commissionRate)) * 100)}–${Math.round(Math.max(...tiers.map((t) => t.commissionRate)) * 100)}%`
+    : maxRate ?? 'recurring';
+
+  return (
+    <main className="min-h-screen bg-gray-950 text-white">
+      {/* Nav */}
+      <nav className="border-b border-white/5 px-6 py-4">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-emerald-500 rounded-lg flex items-center justify-center">
+              <Target className="w-5 h-5 text-white" />
+            </div>
+            <span className="font-semibold text-lg">Partner Portal</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link href="/login">
+              <Button variant="ghost" size="sm" className="text-gray-400 hover:text-white">
+                Sign in
+              </Button>
+            </Link>
+            <Link href="/register">
+              <Button size="sm" className="bg-emerald-600 hover:bg-emerald-500 text-white">
+                Apply Now
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section className="px-6 py-24 text-center">
+        <div className="max-w-3xl mx-auto">
+          <div className="inline-flex items-center gap-2 bg-emerald-500/10 border border-emerald-500/20 rounded-full px-4 py-1.5 text-emerald-400 text-sm mb-8">
+            <Award className="w-4 h-4" />
+            {tiers.length > 0 ? `Tiered ${programName} — up to ${maxRate} recurring` : programName}
+          </div>
+          <h1 className="text-5xl font-bold mb-6 leading-tight">
+            Earn Recurring Commission<br />
+            <span className="text-emerald-400">for Every Merchant You Refer</span>
+          </h1>
+          <p className="text-xl text-gray-400 mb-10 leading-relaxed">
+            Join the {programName} and earn {heroRateRange} recurring commission
+            on every merchant you refer — for the lifetime of their account.
+            The more you refer, the more you earn.
+          </p>
+          <div className="flex items-center justify-center gap-4 flex-wrap">
+            <Link href="/register">
+              <Button size="lg" className="bg-emerald-600 hover:bg-emerald-500 text-white gap-2 px-8">
+                Start Earning <ArrowRight className="w-4 h-4" />
+              </Button>
+            </Link>
+            <a href="#tiers">
+              <Button size="lg" variant="outline" className="border-white/20 text-white hover:bg-white/5 gap-2 px-8">
+                View Commission Tiers
+              </Button>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Stats bar */}
+      <section className="border-y border-white/5 bg-white/2 px-6 py-8">
+        <div className="max-w-4xl mx-auto grid grid-cols-3 gap-8 text-center">
+          {[
+            { value: maxRate ? `Up to ${maxRate}` : 'Competitive', label: 'Recurring commission' },
+            { value: '90 days', label: 'Attribution window' },
+            { value: 'Monthly', label: 'Payout on the 15th' },
+          ].map((s) => (
+            <div key={s.label}>
+              <div className="text-3xl font-bold text-emerald-400 mb-1">{s.value}</div>
+              <div className="text-gray-500 text-sm">{s.label}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Tiers */}
+      <section id="tiers" className="px-6 py-24">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold mb-4">Commission Tiers</h2>
+            <p className="text-gray-400 text-lg">
+              {tiers.length > 0
+                ? 'Automatically unlock higher rates as you grow your partner book. No applications, no negotiations — promotions happen automatically.'
+                : 'Contact us to learn about our commission structure.'}
+            </p>
+          </div>
+          {tiers.length > 0 ? (
+            <div className={`grid grid-cols-1 gap-6 ${tiers.length === 2 ? 'md:grid-cols-2' : tiers.length >= 3 ? 'md:grid-cols-3' : ''}`}>
+              {tiers.map((tier, i) => {
+                const style = TIER_STYLES[i % TIER_STYLES.length];
+                const ratePercent = `${Math.round(tier.commissionRate * 100)}%`;
+                const thresholdLabel = tier.tierThreshold ? `${tier.tierThreshold} merchants` : 'Start here';
+                const merchantsLabel = tier.tierThreshold
+                  ? (i + 1 < tiers.length && tiers[i + 1].tierThreshold
+                    ? `${tier.tierThreshold}–${tiers[i + 1].tierThreshold! - 1} active merchants`
+                    : `${tier.tierThreshold}+ active merchants`)
+                  : `1–${tiers[1]?.tierThreshold ? tiers[1].tierThreshold - 1 : '∞'} active merchants`;
+
+                return (
+                  <div
+                    key={tier.id}
+                    className={`relative rounded-2xl border ${style.border} bg-white/3 p-8 ${style.highlight ? 'ring-2 ring-emerald-500/40' : ''}`}
+                  >
+                    {style.highlight && (
+                      <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-emerald-600 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                        Most Popular
+                      </div>
+                    )}
+                    <div className={`inline-flex px-3 py-1 rounded-full text-sm font-medium ${style.badge} mb-6`}>
+                      {tier.name}
+                    </div>
+                    <div className={`text-5xl font-black bg-gradient-to-r ${style.color} bg-clip-text text-transparent mb-2`}>
+                      {ratePercent}
+                    </div>
+                    <div className="text-gray-400 text-sm mb-4">recurring commission</div>
+                    <div className="border-t border-white/5 pt-4 space-y-2">
+                      <div className="text-sm text-gray-300">{merchantsLabel}</div>
+                      <div className="text-xs text-gray-500">Unlocks at: {thresholdLabel}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="text-center text-gray-500 py-12">
+              Commission tier information is coming soon. <Link href="/register" className="text-emerald-400 underline">Register now</Link> to get started.
+            </div>
+          )}
+          {tiers.length > 1 && (
+            <p className="text-center text-gray-500 text-sm mt-8">
+              Tier upgrades are automatic — hit the threshold and your rate increases immediately.
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="px-6 py-24 bg-white/2 border-y border-white/5">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold mb-4">How It Works</h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {HOW_IT_WORKS.map(({ icon: Icon, step, title, body }) => (
+              <div key={step} className="text-center">
+                <div className="w-14 h-14 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center mx-auto mb-4">
+                  <Icon className="w-6 h-6 text-emerald-400" />
+                </div>
+                <div className="text-xs font-mono text-emerald-600 mb-2">{step}</div>
+                <h3 className="font-semibold mb-2">{title}</h3>
+                <p className="text-gray-500 text-sm leading-relaxed">{body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits */}
+      <section className="px-6 py-24">
+        <div className="max-w-4xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+            <div>
+              <h2 className="text-3xl font-bold mb-4">Everything You Need to Build a Real Income</h2>
+              <p className="text-gray-400 mb-8 leading-relaxed">
+                We built this program for partners who are serious about building recurring revenue,
+                not one-off bonuses.
+              </p>
+              <Link href="/register">
+                <Button className="bg-emerald-600 hover:bg-emerald-500 text-white gap-2">
+                  Apply as a Partner <ArrowRight className="w-4 h-4" />
+                </Button>
+              </Link>
+            </div>
+            <ul className="space-y-4">
+              {BENEFITS.map((b) => (
+                <li key={b} className="flex items-start gap-3">
+                  <CheckCircle className="w-5 h-5 text-emerald-400 flex-shrink-0 mt-0.5" />
+                  <span className="text-gray-300 text-sm leading-relaxed">{b}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="px-6 py-24 bg-emerald-950/30 border-t border-emerald-500/10">
+        <div className="max-w-2xl mx-auto text-center">
+          <h2 className="text-3xl font-bold mb-4">Ready to Start Earning?</h2>
+          <p className="text-gray-400 mb-8">
+            Register your partner account today. Your first referral link is ready in under 2 minutes.
+          </p>
+          <Link href="/register">
+            <Button size="lg" className="bg-emerald-600 hover:bg-emerald-500 text-white gap-2 px-10">
+              Create Partner Account <ArrowRight className="w-4 h-4" />
+            </Button>
+          </Link>
+          <p className="mt-4 text-gray-600 text-sm">
+            Already a partner?{' '}
+            <Link href="/login" className="text-emerald-500 hover:text-emerald-400">
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t border-white/5 px-6 py-8">
+        <div className="max-w-6xl mx-auto flex items-center justify-between text-gray-600 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 bg-emerald-500 rounded flex items-center justify-center">
+              <Target className="w-4 h-4 text-white" />
+            </div>
+            Partner Portal
+          </div>
+          <div>© {new Date().getFullYear()} {companyName}. All rights reserved.</div>
+        </div>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

This PR makes Refferq fully white-label by removing hardcoded strings and adding generic public APIs:

- **DB-driven join page** — \`join/page.tsx\` now fetches program name, company name, and commission tiers from the database instead of hardcoded values. Works for any Refferq deployment without code changes.
- **Public tiers endpoint** — \`GET /api/public/tiers\` returns \`PartnerGroup\` rows ordered by commission rate. Unauthenticated, for use on the public join page.
- **Dynamic tracking snippet** — \`tracking-snippet/route.ts\` reads \`defaultPartnerCode\` from \`ProgramSettings\` instead of a hardcoded referral code.
- **External conversion webhook** — \`POST /api/external/conversion\` allows any integrated billing system to record conversions. Uses HMAC-SHA256 signature verification, idempotency key deduplication, and self-referral protection.
- **Schema additions** — \`Conversion.idempotencyKey\` (unique), \`Conversion.sourceTag\`, \`ProgramSettings.sourceTag\` for multi-instance support.

## How it works

Any Refferq instance can now be configured entirely through the database and environment variables — no code changes required for white-labeling.

## Test plan

- [ ] \`GET /api/public/tiers\` returns commission tiers from DB
- [ ] \`join/page.tsx\` renders program name and tiers from API response
- [ ] \`tracking-snippet\` generates snippet with DB-sourced partner code
- [ ] \`POST /api/external/conversion\` rejects invalid HMAC signatures (401)
- [ ] \`POST /api/external/conversion\` deduplicates by \`idempotency_key\` (200 on repeat)
- [ ] \`POST /api/external/conversion\` rejects self-referrals (422)
- [ ] \`POST /api/external/conversion\` creates conversion and returns 201