### PR TITLE
fix: make /api/auth/me pass through auth middleware

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -5,11 +5,11 @@ import { checkRateLimit } from '@/lib/rate-limit';
 
 export async function POST(request: NextRequest) {
   try {
-    // Rate limit: 3 registration attempts per minute per IP
+    // Rate limit: 30 registration attempts per minute per IP
     const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
       || request.headers.get('x-real-ip')
       || 'unknown';
-    const rateLimit = await checkRateLimit(ip, 'auth/register', 3, 60 * 1000);
+    const rateLimit = await checkRateLimit(ip, 'auth/register', 30, 60 * 1000);
     if (!rateLimit.allowed) {
       return NextResponse.json(
         { success: false, message: 'Too many registration attempts. Please try again later.' },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,10 +10,12 @@ export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
     // 1. Define protected routes
+    const isAuthMeRoute = pathname === '/api/auth/me';
     const isAdminRoute = pathname.startsWith('/api/admin') || pathname.startsWith('/admin');
     const isAffiliateRoute = pathname.startsWith('/api/affiliate') || pathname.startsWith('/affiliate');
+    const isProtectedRoute = isAuthMeRoute || isAdminRoute || isAffiliateRoute;
 
-    if (!isAdminRoute && !isAffiliateRoute) {
+    if (!isProtectedRoute) {
         return NextResponse.next();
     }
 
@@ -58,12 +60,16 @@ export async function middleware(request: NextRequest) {
             return NextResponse.redirect(new URL('/login', request.url));
         }
 
-        // 5. Inject user info into headers for API usage (optional but helpful)
-        const response = NextResponse.next();
-        response.headers.set('x-user-id', payload.userId as string);
-        response.headers.set('x-user-role', userRole);
+        // 5. Inject user info into request headers for API usage
+        const requestHeaders = new Headers(request.headers);
+        requestHeaders.set('x-user-id', payload.userId as string);
+        requestHeaders.set('x-user-role', userRole);
 
-        return response;
+        return NextResponse.next({
+            request: {
+                headers: requestHeaders,
+            },
+        });
     } catch (error) {
         if (pathname.startsWith('/api/')) {
             return NextResponse.json(


### PR DESCRIPTION
## Summary
- Add /api/auth/me to middleware protected routes so token validation runs for session checks.
- For protected API routes, inject user auth context into request headers (x-user-id and x-user-role) using NextResponse.next({ request: { headers }}) so downstream handlers can read it.
- Increase registration rate-limit in POST /api/auth/register from 3 to 30 attempts per minute as requested.

## Why
`/api/auth/me` was not included in middleware protection and was returning 401 even after successful OTP login.
Handlers read x-user-id/x-user-role from request headers, while middleware previously set those headers on the response instead.

## Testing
- npx tsc --noEmit in refferq